### PR TITLE
properly parse NO_SSL env var

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -9,8 +9,9 @@ from flask import abort, Flask, render_template, request
 from redis.exceptions import ConnectionError
 from werkzeug.urls import url_quote_plus
 from werkzeug.urls import url_unquote_plus
+from distutils.util import strtobool
 
-NO_SSL = os.environ.get('NO_SSL', False)
+NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
 TOKEN_SEPARATOR = '~'
 


### PR DESCRIPTION
Bug fix:
The default for a **non existing** `NO_SSL` environment variable is `False`.
When the actual value, in runtime, is `"False"`, the code "ignores" it.
The reason: the code does not **parse** the given string. So it **evaluates** any non empty string (say `"False"`)  as `True`.
To resolve this, the suggested code parses the given string to a boolean value.